### PR TITLE
Set the default currency to EUR

### DIFF
--- a/src/ofxstatement/plugins/bnp.py
+++ b/src/ofxstatement/plugins/bnp.py
@@ -15,6 +15,7 @@ class bnpPlugin(Plugin):
         f = open(filename, 'r', encoding=self.settings.get("charset", "ISO-8859-1"))
         parser =bnpParser(f)
         parser.statement.bank_id = "Bnp"
+        parser.statement.currency = "EUR"
         return parser
 
 


### PR DESCRIPTION
This prevents the following error when importing the OFX file in
gnucash:

LibOFX ERROR: OpenSP parser: otherError (misc parse error):
/tmp/libofxtmpCXEjKT:1:288:E: start tag for "CURDEF" omitted, but its declaration does not permit this

Fix: #8