### PR TITLE
Do not set the charset of the csv file to ISO-8859-1

### DIFF
--- a/src/ofxstatement/plugins/bnp.py
+++ b/src/ofxstatement/plugins/bnp.py
@@ -12,7 +12,7 @@ class bnpPlugin(Plugin):
     """
 
     def get_parser(self, filename):
-        f = open(filename, 'r', encoding=self.settings.get("charset", "ISO-8859-1"))
+        f = open(filename, 'r')
         parser =bnpParser(f)
         parser.statement.bank_id = "Bnp"
         return parser


### PR DESCRIPTION
The csv file is now in UTF-8, do not force ISO-8859-1

$ file CSV_2021-04-06-09.52.csv
CSV_2021-04-06-09.52.csv: UTF-8 Unicode (with BOM) text, with very long lines

Fix: #6