### PR TITLE
Set the FITID to the transaction id

### DIFF
--- a/src/ofxstatement/plugins/bnp.py
+++ b/src/ofxstatement/plugins/bnp.py
@@ -23,6 +23,7 @@ class bnpParser(CsvStatementParser):
     date_format = "%d/%m/%Y"
 
     mappings = {
+        'id': 0,
         'check_no': 0,
         'date': 1,
         'payee': 5,


### PR DESCRIPTION
This remove the following error while importing the transactions in
gnucash:
  start tag for "FITID" omitted, but its declaration does not permit this

Fix: #7